### PR TITLE
1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "is-fhir-date",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "is-fhir-date",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "is-fhir-date",
   "description": "Determines if a given string is a valid FHIR `date` _and_ also checks it for validity.",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "author": "Henrik Joreteg <henrik@joreteg.com>",
   "bugs": {
     "url": "https://github.com/henrikjoreteg/is-fhir-date"


### PR DESCRIPTION
Something strange happened when we released the last version and we released 0.0.1 when the version prior was 1.0.0, so this PR just bumps the latest version to 1.0.1

<img width="815" alt="image" src="https://github.com/HenrikJoreteg/is-fhir-date/assets/78225/d9c134f9-9a2d-45f5-9198-75c828123d5c">
